### PR TITLE
Create XML schema for regulations

### DIFF
--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -1,0 +1,54 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:element name="regulation">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="issue" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volume" type="xs:integer" minOccurs="0" maxOccurs="1" />
+      <xs:element name="registerDate" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="effectiveDate" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="link" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="titles" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="title" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="code" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="statuatoryAuthority" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preamble" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="body" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="contacts" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="contact" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="firstName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="lastName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="agency" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="address" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="city" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="zip" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="phone" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+</xs:schema>

--- a/data_ingest/utils/xml.py
+++ b/data_ingest/utils/xml.py
@@ -7,6 +7,24 @@ PATH = pathlib.Path(__file__).parent.absolute()
 SCHEMA_DIR = os.path.join(PATH, "..", "schemas")
 
 
+def read_xml(string, schema_name):
+    """Reads in XML using the specified schema
+
+    Parameters
+    ----------
+    string : str
+        The XML represented as a string
+    schema_name : str
+        The name of the schema
+
+    Returns
+    -------
+    xml : etree._Element
+    """
+    parser = read_xsd(schema_name)
+    return etree.fromstring(string, parser)
+
+
 def read_xsd(schema_name):
     """Reads an XML schema from the schema directory.
 

--- a/data_ingest/utils/xml.py
+++ b/data_ingest/utils/xml.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+
+from lxml import etree
+
+PATH = pathlib.Path(__file__).parent.absolute()
+SCHEMA_DIR = os.path.join(PATH, "..", "schemas")
+
+
+def read_xsd(schema_name):
+    """Reads an XML schema from the schema directory.
+
+    Parameters
+    ----------
+    schema_name : str
+        The name of the schema in the schema directory
+
+    Returns
+    -------
+    parser : etree.XMLParser
+    """
+    filename = os.path.join(SCHEMA_DIR, f"{schema_name}.xsd")
+    with open(filename, "r") as f:
+        schema_root = etree.XML(f.read())
+    schema = etree.XMLSchema(schema_root)
+    return etree.XMLParser(schema=schema)

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -1,0 +1,56 @@
+import pytest
+from lxml import etree
+
+import data_ingest.utils.xml as xml
+
+
+@pytest.fixture
+def valid_regulation():
+    return """
+        <regulation>
+            <state>VA</state>
+            <issue>1</issue>
+            <titles>
+                <title>
+                    <code>4VAC20-252</code>
+                    <description>Parrots</description>
+                </title>
+                <title>
+                    <code>4VAC20-254</code>
+                    <description>Dogs</description>
+                </title>
+            </titles>
+        </regulation>
+    """
+
+
+@pytest.fixture
+def invalid_regulation():
+    return """
+        <regulation>
+            <state>VA</state>
+            <issue>not an int</issue>
+            <titles>
+                <title>
+                    <code>4VAC20-252</code>
+                    <description>Parrots</description>
+                </title>
+                <title>
+                    <code>4VAC20-254</code>
+                    <description>Dogs</description>
+                </title>
+            </titles>
+        </regulation>
+    """
+
+
+def test_parser_validates_valid_reg(valid_regulation):
+    parser = xml.read_xsd("regulation")
+    root = etree.fromstring(valid_regulation, parser)
+    assert isinstance(root, etree._Element)
+
+
+def test_parser_raises_on_invalid_reg(invalid_regulation):
+    parser = xml.read_xsd("regulation")
+    with pytest.raises(etree.XMLSyntaxError):
+        root = etree.fromstring(invalid_regulation, parser)

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -45,12 +45,10 @@ def invalid_regulation():
 
 
 def test_parser_validates_valid_reg(valid_regulation):
-    parser = xml.read_xsd("regulation")
-    root = etree.fromstring(valid_regulation, parser)
+    root = xml.read_xml(valid_regulation, "regulation")
     assert isinstance(root, etree._Element)
 
 
 def test_parser_raises_on_invalid_reg(invalid_regulation):
-    parser = xml.read_xsd("regulation")
     with pytest.raises(etree.XMLSyntaxError):
-        root = etree.fromstring(invalid_regulation, parser)
+        xml.read_xml(invalid_regulation, "regulation")


### PR DESCRIPTION
### Description 

Address #7 to add an XML schema for regulations. In addition to implementing a regulation schema, this PR implements code for reading and parsing XML using that schema.

### Test instructions

`pytest test_data_ingest/utils/test_xml.py`