### PR TITLE
Update VA regulation pull to write to XML

### DIFF
--- a/data_ingest/models/base.py
+++ b/data_ingest/models/base.py
@@ -18,3 +18,6 @@ class DataModel:
         data = self.to_dict()
         with open(filename, "w") as f:
             json.dump(data, f, indent=4)
+
+    def to_xml(self):
+        raise NotImplementedError

--- a/data_ingest/models/base.py
+++ b/data_ingest/models/base.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 import json
 
+from bs4 import BeautifulSoup
+
 
 @dataclass
 class DataModel:
@@ -51,9 +53,10 @@ class DataModel:
         filename : str
             The filename for the serialized JSON output.
         """
-        xml = self.xml_template()
+        # We use the bs4 parser to prettify the XML prior to writing
+        xml = BeautifulSoup(self.xml_template(), "xml")
         with open(filename, "w") as f:
-            f.write(xml)
+            f.write(xml.prettify())
 
     def xml_template(self):
         """Converts the data object to XML. The XML templates are in the schemas

--- a/data_ingest/models/base.py
+++ b/data_ingest/models/base.py
@@ -53,10 +53,12 @@ class DataModel:
         filename : str
             The filename for the serialized JSON output.
         """
-        # We use the bs4 parser to prettify the XML prior to writing
-        xml = BeautifulSoup(self.xml_template(), "xml")
-        with open(filename, "w") as f:
-            f.write(xml.prettify())
+        xml = self.xml_template()
+        if xml:
+            # We use the bs4 parser to prettify the XML prior to writing
+            xml = BeautifulSoup(self.xml_template(), "xml")
+            with open(filename, "w") as f:
+                f.write(xml.prettify())
 
     def xml_template(self):
         """Converts the data object to XML. The XML templates are in the schemas

--- a/data_ingest/models/base.py
+++ b/data_ingest/models/base.py
@@ -9,15 +9,60 @@ class DataModel:
         """Loads the DataModel object from a dictionary containing the field names."""
         return cls(**data)
 
-    def to_dict(self):
-        """Converts the DataModel to a dictionary."""
-        return vars(self)
+    def to_dict(self, drop_empty=False):
+        """Converts the DataModel to a dictionary.
+
+        Parameters
+        ----------
+        drop_empty : bool
+            If True, omits top levels keys that are None
+
+        Returns
+        -------
+        data : dict
+            A dictionary representation of the odel
+
+        """
+        data = vars(self)
+        if drop_empty:
+            keys = list(data.keys())
+            for key in keys:
+                if data[key] is None:
+                    del data[key]
+        return data
 
     def to_json(self, filename):
-        """Serializes the DataModel as JSON."""
+        """Serializes the DataModel as JSON.
+
+        Parameters
+        ----------
+        filename : str
+            The filename for the serialized JSON output.
+        """
         data = self.to_dict()
         with open(filename, "w") as f:
             json.dump(data, f, indent=4)
 
-    def to_xml(self):
+    def to_xml(self, filename):
+        """Serializes the DataModel as XML
+
+        Parameters
+        ----------
+        filename : str
+            The filename for the serialized JSON output.
+        """
+        xml = self.xml_template()
+        with open(filename, "w") as f:
+            f.write(xml)
+
+    def xml_template(self):
+        """Converts the data object to XML. The XML templates are in the schemas
+        directory.
+
+        Returns
+        -------
+        xml : str
+            An XML representation of the data object
+
+        """
         raise NotImplementedError

--- a/data_ingest/models/contact.py
+++ b/data_ingest/models/contact.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from data_ingest.models.base import DataModel
+
+
+@dataclass
+class Contact(DataModel):
+    first_name: str = None
+    last_name: str = None
+    agency: str = None
+    address: str = None
+    city: str = None
+    state: str = None
+    zip_code: str = None
+    phone: str = None
+    email: str = None

--- a/data_ingest/models/contact.py
+++ b/data_ingest/models/contact.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from data_ingest.models.base import DataModel
+from data_ingest.utils.xml import get_jinja_template
 
 
 @dataclass
@@ -14,3 +15,8 @@ class Contact(DataModel):
     zip_code: str = None
     phone: str = None
     email: str = None
+
+    def xml_template(self):
+        data = self.to_dict(drop_empty=True)
+        template = get_jinja_template("contact")
+        return template.render(data=data).strip()

--- a/data_ingest/models/regulation.py
+++ b/data_ingest/models/regulation.py
@@ -43,4 +43,5 @@ class Regulation(DataModel):
         if validate_xml(xml, "regulation"):
             return xml
         else:
-            raise ValueError(f"XML for regulation {id} is invalid")
+            print(f"WARNING: XML for regulation {self.id} is invalid")
+            return None

--- a/data_ingest/models/regulation.py
+++ b/data_ingest/models/regulation.py
@@ -3,6 +3,7 @@ import datetime
 import uuid
 
 from data_ingest.models.base import DataModel
+from data_ingest.utils.xml import get_jinja_template
 
 
 @dataclass
@@ -12,15 +13,20 @@ class Regulation(DataModel):
     issue: str = None
     volume: str = None
 
+    notice: str = None
     regulation_number: str = None
     description: str = None
     summary: str = None
     preamble: str = None
     body: str = None
 
+    status: str = None
+    title: str = None
+    chapter: str = None
+    chapter_description: str = None
     titles: list = None
     authority: str = None
-    contact: str = None
+    contacts: list = None
 
     register_date: datetime.datetime = None
     effective_date: datetime.datetime = None
@@ -29,3 +35,8 @@ class Regulation(DataModel):
     link: str = None
 
     extra_attributes: dict = None
+
+    def xml_template(self):
+        data = self.to_dict(drop_empty=True)
+        template = get_jinja_template("regulation")
+        return template.render(data=data).strip()

--- a/data_ingest/models/regulation.py
+++ b/data_ingest/models/regulation.py
@@ -3,7 +3,7 @@ import datetime
 import uuid
 
 from data_ingest.models.base import DataModel
-from data_ingest.utils.xml import get_jinja_template
+from data_ingest.utils.xml import get_jinja_template, validate_xml
 
 
 @dataclass
@@ -39,4 +39,8 @@ class Regulation(DataModel):
     def xml_template(self):
         data = self.to_dict(drop_empty=True)
         template = get_jinja_template("regulation")
-        return template.render(data=data).strip()
+        xml = template.render(data=data).strip()
+        if validate_xml(xml, "regulation"):
+            return xml
+        else:
+            raise ValueError(f"XML for regulation {id} is invalid")

--- a/data_ingest/regs/va.py
+++ b/data_ingest/regs/va.py
@@ -202,9 +202,15 @@ def _parse_html(html):
     reg["issue"] = issue
     reg["volume"] = volume
 
+    reg["notice"] = _get_notice(html)
     reg["content"] = _get_regulation_content(html)
     reg["summary"] = _get_summary(html)
     reg["preamble"] = _get_summary(html, summary_class="preamble")
+
+    reg["status"] = _get_title_info(html, "Status")
+    reg["title"] = _get_title_info(html, "Title")
+    reg["chapter"] = _get_title_info(html, "Chapter")
+    reg["chapter_description"] = _get_title_info(html, "Description")
 
     reg["titles"] = _get_titles(metadata)
     reg["authority"] = _get_target_metadata(metadata, "Authority")
@@ -213,6 +219,42 @@ def _parse_html(html):
     reg["register_date"] = date
     reg["effective_date"] = _get_target_metadata(metadata, "Effective Date")
     return reg
+
+
+def _get_title_info(html, key):
+    """Pulls title information for the regulation.
+
+    Parameters
+    ----------
+    html : bs4.BeautifulSoupt
+        The bs4 representation of the site
+    key : str
+        The last element of the class name for the div to target
+
+    Returns
+    -------
+    title_info : str
+        The relevant title information
+    """
+    div = html.find("div", {"id": f"ContentPlaceHolder1_div{key}"})
+    return div.text if div else None
+
+
+def _get_notice(html):
+    """Pulls title information for the regulation.
+
+    Parameters
+    ----------
+    html : bs4.BeautifulSoupt
+        The bs4 representation of the site
+
+    Returns
+    -------
+    notice : str
+        The string of the notice
+    """
+    para = html.find("p", class_="notice0")
+    return para.decode_contents() if para else None
 
 
 def _get_regulation_content(html):

--- a/data_ingest/regs/va.py
+++ b/data_ingest/regs/va.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 from time import sleep
@@ -144,16 +143,6 @@ def normalize_regulation(regulation):
             }
         )
         normalized_reg["contacts"] = [contact]
-
-    titles = list()
-    extra_attributes = {"title_descriptions": dict()}
-    for item in regulation["titles"]:
-        title = item["title"]
-        description = item["description"]
-        titles.append(title)
-        extra_attributes["title_descriptions"][title] = description
-    normalized_reg["titles"] = titles
-    normalized_reg["extra_attributes"] = json.dumps(extra_attributes)
 
     normalized_reg["effective_date"] = extract_date(regulation["effective_date"])
     normalized_reg["register_date"] = extract_date(regulation["register_date"])
@@ -434,7 +423,7 @@ def _get_titles(metadata):
                 title, description = tuple(text.split(".")[:2])
                 titles.append(
                     {
-                        "title": clean_whitespace(title),
+                        "code": clean_whitespace(title),
                         "description": clean_whitespace(description),
                     }
                 )

--- a/data_ingest/regs/va.py
+++ b/data_ingest/regs/va.py
@@ -33,8 +33,7 @@ def _get_va_regulation_dir():
 
 
 def load_va_regulations(sleep_time=1):
-    """Loads the all of the regulations from the VA registry into the Postgres database.
-    If there is already an entry for an issue of the registry, it will be overwritten.
+    """Downloads and stores VA regulations locally as XML files.
 
     Parameters
     ----------

--- a/data_ingest/regs/va.py
+++ b/data_ingest/regs/va.py
@@ -253,10 +253,7 @@ def _get_regulation_content(html):
         elif para["class"][0] == "sectind0":
             if not text:
                 text = str()
-            # Remove strikethrough text
-            for strikethrough in para.find_all("s"):
-                strikethrough.decompose()
-            text += f"{para.text} "
+            text += f"{para.decode_contents()} "
     _add_reg_text(regulation, description, text)
     return content
 

--- a/data_ingest/regs/va.py
+++ b/data_ingest/regs/va.py
@@ -4,6 +4,7 @@ from time import sleep
 
 import tqdm
 
+from data_ingest.models.contact import Contact
 from data_ingest.models.regulation import Regulation
 from data_ingest.utils.data_cleaning import clean_whitespace, extract_date
 import data_ingest.utils.database as db
@@ -111,6 +112,12 @@ def normalize_regulation(regulation):
     for subtitle, content in regulation["content"].items():
         body += f"{subtitle}. {content['description']}\n{content['text']}\n"
     normalized_reg["body"] = body if body else None
+
+    contact = regulation.get("contact", None)
+    if contact:
+        first_name, last_name = tuple(contact.split(",")[0].split())
+        contact = Contact.from_dict({"first_name": first_name, "last_name": last_name})
+        normalized_reg["contacts"] = [contact]
 
     titles = list()
     extra_attributes = {"title_descriptions": dict()}

--- a/data_ingest/schemas/contact.xml
+++ b/data_ingest/schemas/contact.xml
@@ -1,0 +1,24 @@
+{%- if "first_name" in data -%}
+<firstName>{{ data["first_name"] }}</firstName>
+{% endif %}
+{%- if "last_name" in data -%}
+<lastName>{{ data["last_name"] }}</lastName>
+{% endif %}
+{%- if "agency" in data -%}
+<agency>{{ data["agency"] }}</agency>
+{% endif %}
+{%- if "city" in data -%}
+<city>{{ data["city"] }}</city>
+{% endif %}
+{%- if "state" in data -%}
+<state>{{ data["state"] }}</state>
+{% endif %}
+{%- if "zip_code" in data -%}
+<zipCode>{{ data["zip_code"] }}</zipCode>
+{% endif %}
+{%- if "phone" in data -%}
+<phone>{{ data["phone"] }}</phone>
+{% endif %}
+{%- if "email" in data -%}
+<email>{{ data["email"] }}</email>
+{% endif %}

--- a/data_ingest/schemas/regulation.xml
+++ b/data_ingest/schemas/regulation.xml
@@ -8,9 +8,12 @@
 {% if "volume" in data %}
   <volume>{{ data["volume"] }}</volume>
 {% endif %}
+
+{% autoescape false %}
 {% if "notice" in data %}
   <notice>{{ data["notice"] }}</notice>
 {% endif %}
+{% endautoescape %}
 {% if "registerDate" in data %}
   <registerDate>{{ data["register_date"].date().isoformat() }}</registerDate>
 {% endif %}
@@ -36,8 +39,7 @@
 <titles>
   {% for title in data["titles"] %}
   <title>
-    <code>{{ title["title"] }}</code>
-    <description>{{ title["description"] }}</description>
+    <code>{{ title }}</code>
   </title>
   {% endfor %}
 </titles>

--- a/data_ingest/schemas/regulation.xml
+++ b/data_ingest/schemas/regulation.xml
@@ -8,7 +8,6 @@
 {% if "volume" in data %}
   <volume>{{ data["volume"] }}</volume>
 {% endif %}
-
 {% autoescape false %}
 {% if "notice" in data %}
   <notice>{{ data["notice"] }}</notice>
@@ -39,7 +38,8 @@
 <titles>
   {% for title in data["titles"] %}
   <title>
-    <code>{{ title }}</code>
+    <code>{{ title.get("code", "None") }}</code>
+    <description>{{ title.get("description", "None") }}</description>
   </title>
   {% endfor %}
 </titles>

--- a/data_ingest/schemas/regulation.xml
+++ b/data_ingest/schemas/regulation.xml
@@ -35,7 +35,10 @@
 {% if "titles" in data %}
 <titles>
   {% for title in data["titles"] %}
-  <title>{{ title["title"] }}: {{ title["description"] }}</title>
+  <title>
+    <code>{{ title["title"] }}</code>
+    <description>{{ title["description"] }}</description>
+  </title>
   {% endfor %}
 </titles>
 {% endif %}

--- a/data_ingest/schemas/regulation.xml
+++ b/data_ingest/schemas/regulation.xml
@@ -35,7 +35,7 @@
 {% if "titles" in data %}
 <titles>
   {% for title in data["titles"] %}
-  <title>{{ title }}</title>
+  <title>{{ title["title"] }}: {{ title["description"] }}</title>
   {% endfor %}
 </titles>
 {% endif %}
@@ -56,7 +56,7 @@
   <body>
     {{ data["body"] }}
   </body>
-    {% endif %}
+{% endif %}
 <contacts>
 {% if "contacts" in data %}
   <contact>

--- a/data_ingest/schemas/regulation.xml
+++ b/data_ingest/schemas/regulation.xml
@@ -1,0 +1,70 @@
+<regulation>
+{% if "state" in data %}
+  <state>{{ data["state"] }}</state>
+{% endif %}
+{% if "issue" in data %}
+  <issue>{{ data["issue"] }}</issue>
+{% endif %}
+{% if "volume" in data %}
+  <volume>{{ data["volume"] }}</volume>
+{% endif %}
+{% if "notice" in data %}
+  <notice>{{ data["notice"] }}</notice>
+{% endif %}
+{% if "registerDate" in data %}
+  <registerDate>{{ data["register_date"].date().isoformat() }}</registerDate>
+{% endif %}
+{% if "effective_date" in data %}
+  <effectiveDate>{{ data["effective_date"].date().isoformat() }}</effectiveDate>
+{% endif %}
+{% if "link" in data %}
+  <link>{{ data["link"] }}</link>
+{% endif %}
+{% if "status" in data %}
+  <status>{{ data["status"] }}</status>
+{% endif %}
+{% if "chapter" in data %}
+  <chapter>{{ data["chapter"] }}</chapter>
+{% endif %}
+{% if "chapter_description" in data %}
+  <chapterDescription>{{ data["chapter_descriptoin"] }}</chapterDescription>
+{% endif %}
+{% if "title" in data %}
+  <title>{{ data["title"] }}</title>
+{% endif %}
+{% if "titles" in data %}
+<titles>
+  {% for title in data["titles"] %}
+  <title>{{ title }}</title>
+  {% endfor %}
+</titles>
+{% endif %}
+{% if "authority" in data %}
+  <statuatoryAuthority>{{ data["authority"] }}</statuatoryAuthority>
+{% endif %}
+{% if "description" in data %}
+  <description>{{ data["description"] }}</description>
+{% endif %}
+{% if "preamble" in data %}
+  <preamble>{{ data["preamble"] }}</preamble>
+{% endif %}
+{% if "summary" in data %}
+  <summary>{{ data["summary"] }}</summary>
+{% endif %}
+{% autoescape false %}
+{% if "body" in data %}
+  <body>
+    {{ data["body"] }}
+  </body>
+    {% endif %}
+<contacts>
+{% if "contacts" in data %}
+  <contact>
+{% for contact in data["contacts"] %}
+{{ contact.xml_template() }}
+{% endfor %}
+  </contact>
+{% endif %}
+{% endautoescape %}
+</contacts>
+</regulation>

--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -5,27 +5,33 @@
       <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="issue" type="xs:integer" minOccurs="0" maxOccurs="1"/>
       <xs:element name="volume" type="xs:integer" minOccurs="0" maxOccurs="1" />
-      <xs:element name="notice" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="notice" minOccurs="0" maxOccurs="1" />
       <xs:element name="registerDate" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="effectiveDate" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="link" type="xs:string" minOccurs="0" maxOccurs="1" />
-      <xs:element name="status" type="xs:string" minOccurs="0" maxOccurs="1" />
-      <xs:element name="chapter" type="xs:string" minOccurs="0" maxOccurs="1" />
-      <xs:element name="chapterDescription" type="xs:string" minOccurs="0" maxOccurs="1" />
-      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="status" minOccurs="0" maxOccurs="1" />
+      <xs:element name="chapter" minOccurs="0" maxOccurs="1" />
+      <xs:element name="chapterDescription" minOccurs="0" maxOccurs="1" />
+      <xs:element name="title" minOccurs="0" maxOccurs="1" />
       <xs:element name="titles" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="title" type="xs:string" maxOccurs="unbounded">
+            <xs:element name="title" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="code" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="description" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
             </xs:element>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="statuatoryAuthority" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="preamble" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="summary" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="body" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="statuatoryAuthority" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preamble" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="body" minOccurs="0" maxOccurs="1"/>
       <xs:element name="contacts" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType>
           <xs:sequence>

--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -5,19 +5,18 @@
       <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="issue" type="xs:integer" minOccurs="0" maxOccurs="1"/>
       <xs:element name="volume" type="xs:integer" minOccurs="0" maxOccurs="1" />
+      <xs:element name="notice" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="registerDate" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="effectiveDate" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="link" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="status" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="chapter" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="chapterDescription" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="titles" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="title" maxOccurs="unbounded">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="code" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                  <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                </xs:sequence>
-              </xs:complexType>
+            <xs:element name="title" type="xs:string" maxOccurs="unbounded">
             </xs:element>
           </xs:sequence>
         </xs:complexType>

--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -39,7 +39,7 @@
                   <xs:element name="address" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="city" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                  <xs:element name="zip_code" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="zipCode" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="phone" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 </xs:sequence>

--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -39,7 +39,7 @@
                   <xs:element name="address" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="city" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                  <xs:element name="zip" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="zip_code" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="phone" type="xs:string" minOccurs="0" maxOccurs="1"/>
                   <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 </xs:sequence>

--- a/data_ingest/schemas/regulation.xsd
+++ b/data_ingest/schemas/regulation.xsd
@@ -3,8 +3,8 @@
   <xs:complexType>
     <xs:sequence>
       <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="issue" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="volume" type="xs:integer" minOccurs="0" maxOccurs="1" />
+      <xs:element name="issue" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volume" minOccurs="0" maxOccurs="1" />
       <xs:element name="notice" minOccurs="0" maxOccurs="1" />
       <xs:element name="registerDate" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="effectiveDate" type="xs:string" minOccurs="0" maxOccurs="1" />

--- a/data_ingest/utils/config.py
+++ b/data_ingest/utils/config.py
@@ -25,3 +25,27 @@ def read_config(name):
     with open(filename, "r") as f:
         config = yaml.load(f, Loader=yaml.SafeLoader)
     return config
+
+
+def local_regs_directory():
+    """Sets the local data directory for storing downloaded regulations. First looks for
+    the CIVIC_JABBER_DATA_DIR environmental variable. If that doesn't exist, the data
+    directory defaults to ~/.civic_jabber/regs
+
+    Returns
+    -------
+    local_directory : path-like
+        The directory for storing locally downloaded files
+    """
+    local_directory = os.environ.get("CIVIC_JABBER_DATA_DIR", None)
+    if not local_directory:
+        civic_jabber_dir = os.path.join(os.path.expanduser("~"), ".civic_jabber")
+
+        if not os.path.exists(civic_jabber_dir):
+            os.mkdir(civic_jabber_dir)
+
+        local_directory = os.path.join(civic_jabber_dir, "regs")
+        if not os.path.exists(local_directory):
+            os.mkdir(local_directory)
+
+    return local_directory

--- a/data_ingest/utils/config.py
+++ b/data_ingest/utils/config.py
@@ -37,15 +37,15 @@ def local_regs_directory():
     local_directory : path-like
         The directory for storing locally downloaded files
     """
-    local_directory = os.environ.get("CIVIC_JABBER_DATA_DIR", None)
-    if not local_directory:
+    civic_jabber_dir = os.environ.get("CIVIC_JABBER_DATA_DIR", None)
+    if not civic_jabber_dir:
         civic_jabber_dir = os.path.join(os.path.expanduser("~"), ".civic_jabber")
 
         if not os.path.exists(civic_jabber_dir):
             os.mkdir(civic_jabber_dir)
 
-        local_directory = os.path.join(civic_jabber_dir, "regs")
-        if not os.path.exists(local_directory):
-            os.mkdir(local_directory)
+    local_directory = os.path.join(civic_jabber_dir, "regs")
+    if not os.path.exists(local_directory):
+        os.mkdir(local_directory)
 
     return local_directory

--- a/data_ingest/utils/data_cleaning.py
+++ b/data_ingest/utils/data_cleaning.py
@@ -42,3 +42,51 @@ def extract_date(text):
     if MONTH_DAY_YEAR_RE.search(text):
         start, end = MONTH_DAY_YEAR_RE.search(text).span()
         return datetime.datetime.strptime(text[start:end], "%B %d, %Y")
+
+
+EMAIL_RE = re.compile(r"[a-zA-Z]*@[a-z]*\.(com|gov)")
+
+
+def extract_email(text):
+    """Extracts an email from a string
+
+    Parameters
+    ----------
+    text : str
+        The text to clean
+
+    Returns
+    -------
+    email : str
+        The email
+    """
+    if not isinstance(text, str):
+        return None
+
+    if EMAIL_RE.search(text):
+        start, end = EMAIL_RE.search(text).span()
+        return text[start:end]
+
+
+PHONE_NUMBER_RE = re.compile(r"\d{3}-\d{3}-\d{4}")
+
+
+def extract_phone_number(text):
+    """Extracts an phone number from a string
+
+    Parameters
+    ----------
+    text : str
+        The text to clean
+
+    Returns
+    -------
+    phone_number : str
+        The phone number
+    """
+    if not isinstance(text, str):
+        return None
+
+    if PHONE_NUMBER_RE.search(text):
+        start, end = PHONE_NUMBER_RE.search(text).span()
+        return text[start:end]

--- a/data_ingest/utils/xml.py
+++ b/data_ingest/utils/xml.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from lxml import etree
 
 PATH = pathlib.Path(__file__).parent.absolute()
@@ -42,3 +43,35 @@ def read_xsd(schema_name):
         schema_root = etree.XML(f.read())
     schema = etree.XMLSchema(schema_root)
     return etree.XMLParser(schema=schema)
+
+
+def get_jinja_env():
+    """Returns the Jinja environment for XML templating
+
+    Returns
+    --------
+    env : jinja2.Environment
+    """
+    return Environment(
+        loader=FileSystemLoader(searchpath=SCHEMA_DIR),
+        autoescape=select_autoescape(["xml"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=False,
+    )
+
+
+def get_jinja_template(template_name):
+    """Loads a jinja template from the schemas directory
+
+    Parameters
+    ----------
+    template_name : str
+        The name of the XML template to load
+
+    Returns
+    -------
+    template : jinja2.Template
+    """
+    env = get_jinja_env()
+    return env.get_template(f"{template_name}.xml")

--- a/data_ingest/utils/xml.py
+++ b/data_ingest/utils/xml.py
@@ -26,6 +26,28 @@ def read_xml(string, schema_name):
     return etree.fromstring(string, parser)
 
 
+def validate_xml(string, schema_name):
+    """Validates an XML string against the specified schema.
+
+    Parameters
+    ----------
+    string : str
+        The XML represented as a string
+    schema_name : str
+        The name of the schema
+
+    Returns
+    -------
+    valid : bool
+        True if the XML is valid, else False
+    """
+    try:
+        read_xml(string, schema_name)
+        return True
+    except etree.XMLSyntaxError:
+        return False
+
+
 def read_xsd(schema_name):
     """Reads an XML schema from the schema directory.
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 beautifulsoup4
 click
+Jinja2
 lxml
 newspaper3k
 pandas

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,8 +13,10 @@ feedfinder2==0.0.4        # via newspaper3k
 feedparser==6.0.1         # via newspaper3k
 idna==2.10                # via requests, tldextract
 jieba3k==0.35.1           # via newspaper3k
+jinja2==2.11.2            # via -r requirements/base.in
 joblib==0.17.0            # via nltk
 lxml==4.5.2               # via -r requirements/base.in, newspaper3k
+markupsafe==1.1.1         # via jinja2
 newspaper3k==0.2.8        # via -r requirements/base.in
 nltk==3.5                 # via newspaper3k
 numpy==1.19.1             # via pandas

--- a/test_data_ingest/models/test_base.py
+++ b/test_data_ingest/models/test_base.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import json
 
+from bs4 import BeautifulSoup
 import pytest
 
 from data_ingest.models.base import DataModel
@@ -46,7 +47,8 @@ def test_date_model_serializes_to_xml(tmpdir):
 
     with open(filename, "r") as f:
         xml = f.read()
-    assert xml == data_model.xml_template()
+
+    assert xml == BeautifulSoup(data_model.xml_template(), "xml").prettify()
 
 
 def test_base_raises_with_no_xml_method():

--- a/test_data_ingest/models/test_base.py
+++ b/test_data_ingest/models/test_base.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 import json
 
+import pytest
+
 from data_ingest.models.base import DataModel
 
 
@@ -25,3 +27,10 @@ def test_date_model_serializes_to_json(tmpdir):
     with open(filename, "r") as f:
         data_json = json.load(f)
     assert data_json == data_model.to_dict()
+
+
+def test_base_raises_with_no_xml_method():
+    data = {"first_name": "Matt", "last_name": "Robinson"}
+    data_model = MockDataModel.from_dict(data)
+    with pytest.raises(NotImplementedError):
+        data_model.to_xml()

--- a/test_data_ingest/models/test_base.py
+++ b/test_data_ingest/models/test_base.py
@@ -4,12 +4,21 @@ import json
 import pytest
 
 from data_ingest.models.base import DataModel
+from data_ingest.utils.xml import get_jinja_template
 
 
 @dataclass
-class MockDataModel(DataModel):
+class MockDataModelBase(DataModel):
     first_name: str
     last_name: str
+
+
+@dataclass
+class MockDataModel(MockDataModelBase):
+    def xml_template(self):
+        data = self.to_dict()
+        template = get_jinja_template("contact")
+        return template.render(data=data)
 
 
 def test_data_model_loads_from_dict():
@@ -29,8 +38,19 @@ def test_date_model_serializes_to_json(tmpdir):
     assert data_json == data_model.to_dict()
 
 
-def test_base_raises_with_no_xml_method():
+def test_date_model_serializes_to_xml(tmpdir):
+    filename = f"{tmpdir.dirname}/mock_output.xml"
     data = {"first_name": "Matt", "last_name": "Robinson"}
     data_model = MockDataModel.from_dict(data)
+    data_model.to_xml(filename)
+
+    with open(filename, "r") as f:
+        xml = f.read()
+    assert xml == data_model.xml_template()
+
+
+def test_base_raises_with_no_xml_method():
+    data = {"first_name": "Matt", "last_name": "Robinson"}
+    data_model = MockDataModelBase.from_dict(data)
     with pytest.raises(NotImplementedError):
-        data_model.to_xml()
+        data_model.xml_template()

--- a/test_data_ingest/models/test_contact.py
+++ b/test_data_ingest/models/test_contact.py
@@ -1,5 +1,3 @@
-import datetime
-
 from data_ingest.models.contact import Contact
 
 

--- a/test_data_ingest/models/test_contact.py
+++ b/test_data_ingest/models/test_contact.py
@@ -1,0 +1,21 @@
+import datetime
+
+from data_ingest.models.contact import Contact
+
+
+MOCK_CONTACT = {
+    "first_name": "Jabber",
+    "last_name": "Parrot",
+    "agency": "Parrot Commission",
+    "address": "123 Parrot Rd",
+    "city": "Parrotville",
+    "state": "PA",
+    "zip_code": "22341",
+    "phone": "1-800-PARROT",
+    "email": "jabber@fake.email",
+}
+
+
+def test_contact_loads_from_dict():
+    contact = Contact.from_dict(MOCK_CONTACT)
+    assert contact.to_dict() == MOCK_CONTACT

--- a/test_data_ingest/models/test_contact.py
+++ b/test_data_ingest/models/test_contact.py
@@ -14,6 +14,23 @@ MOCK_CONTACT = {
 }
 
 
+CONTACT_XML = """
+<firstName>Jabber</firstName>
+<lastName>Parrot</lastName>
+<agency>Parrot Commission</agency>
+<city>Parrotville</city>
+<state>PA</state>
+<zipCode>22341</zipCode>
+<phone>1-800-PARROT</phone>
+<email>jabber@fake.email</email>
+""".strip()
+
+
 def test_contact_loads_from_dict():
     contact = Contact.from_dict(MOCK_CONTACT)
     assert contact.to_dict() == MOCK_CONTACT
+
+
+def test_contact_builds_xml():
+    contact = Contact.from_dict(MOCK_CONTACT)
+    assert contact.xml_template() == CONTACT_XML

--- a/test_data_ingest/models/test_regulation.py
+++ b/test_data_ingest/models/test_regulation.py
@@ -20,7 +20,7 @@ MOCK_REGULATION = {
     "summary": "This is such a great reg",
     "preamble": "This is such a great reg",
     "titles": [{"title": "VA-001", "description": "Fish"}],
-    "contacts": Contact.from_dict({"first_name": "Jabber", "last_name": "Robinson"}),
+    "contacts": [Contact.from_dict({"first_name": "Jabber", "last_name": "Robinson"})],
     "authority": "Parrot law, subsection 4",
     "effective_date": datetime.datetime(2020, 6, 8),
     "register_date": datetime.datetime(2020, 7, 20),
@@ -30,6 +30,43 @@ MOCK_REGULATION = {
 }
 
 
+REGULATION_XML = """
+<regulation>
+  <state>VA</state>
+  <issue>14</issue>
+  <volume>19</volume>
+  <notice>Notice: this is a great reg!</notice>
+  <effectiveDate>2020-06-08</effectiveDate>
+  <link>https://thebestregs.com</link>
+  <status>Final Regulation</status>
+  <chapter>Chapter 4</chapter>
+  <chapterDescription></chapterDescription>
+  <title>14-1831</title>
+<titles>
+  <title>VA-001: Fish</title>
+</titles>
+  <statuatoryAuthority>Parrot law, subsection 4</statuatoryAuthority>
+  <description>The best reg ever!</description>
+  <preamble>This is such a great reg</preamble>
+  <summary>This is such a great reg</summary>
+  <body>
+    You really don't want to read this whole thing ...
+  </body>
+<contacts>
+  <contact>
+<firstName>Jabber</firstName>
+<lastName>Robinson</lastName>
+  </contact>
+</contacts>
+</regulation>
+""".strip()
+
+
 def test_regulation_loads_from_dict():
     regulation = Regulation.from_dict(MOCK_REGULATION)
     assert regulation.to_dict() == MOCK_REGULATION
+
+
+def test_regulation_builds_xml():
+    regulation = Regulation.from_dict(MOCK_REGULATION)
+    assert regulation.xml_template() == REGULATION_XML

--- a/test_data_ingest/models/test_regulation.py
+++ b/test_data_ingest/models/test_regulation.py
@@ -43,7 +43,10 @@ REGULATION_XML = """
   <chapterDescription></chapterDescription>
   <title>14-1831</title>
 <titles>
-  <title>VA-001: Fish</title>
+  <title>
+    <code>VA-001</code>
+    <description>Fish</description>
+  </title>
 </titles>
   <statuatoryAuthority>Parrot law, subsection 4</statuatoryAuthority>
   <description>The best reg ever!</description>

--- a/test_data_ingest/models/test_regulation.py
+++ b/test_data_ingest/models/test_regulation.py
@@ -8,7 +8,7 @@ MOCK_REGULATION = {
     "id": "1",
     "chapter": "Chapter 4",
     "chapter_description": "Fish regulations",
-    "notice": "Notice: this is a great reg!",
+    "notice": "<u>Notice:</u> this is a great reg!",
     "title": "14-1831",
     "status": "Final Regulation",
     "state": "VA",
@@ -19,7 +19,7 @@ MOCK_REGULATION = {
     "body": "You <s>really</s> don't want to read this whole thing ...",
     "summary": "This is such a great reg",
     "preamble": "This is such a great reg",
-    "titles": [{"title": "VA-001", "description": "Fish"}],
+    "titles": [{"code": "VA-001", "description": "Fish"}],
     "contacts": [Contact.from_dict({"first_name": "Jabber", "last_name": "Robinson"})],
     "authority": "Parrot law, subsection 4",
     "effective_date": datetime.datetime(2020, 6, 8),
@@ -35,7 +35,7 @@ REGULATION_XML = """
   <state>VA</state>
   <issue>14</issue>
   <volume>19</volume>
-  <notice>Notice: this is a great reg!</notice>
+  <notice><u>Notice:</u> this is a great reg!</notice>
   <effectiveDate>2020-06-08</effectiveDate>
   <link>https://thebestregs.com</link>
   <status>Final Regulation</status>

--- a/test_data_ingest/models/test_regulation.py
+++ b/test_data_ingest/models/test_regulation.py
@@ -1,10 +1,16 @@
 import datetime
 
+from data_ingest.models.contact import Contact
 from data_ingest.models.regulation import Regulation
 
 
 MOCK_REGULATION = {
     "id": "1",
+    "chapter": "Chapter 4",
+    "chapter_description": "Fish regulations",
+    "notice": "Notice: this is a great reg!",
+    "title": "14-1831",
+    "status": "Final Regulation",
     "state": "VA",
     "issue": "14",
     "volume": "19",
@@ -14,7 +20,7 @@ MOCK_REGULATION = {
     "summary": "This is such a great reg",
     "preamble": "This is such a great reg",
     "titles": [{"title": "VA-001", "description": "Fish"}],
-    "contact": "Jabber Robinson, jabber@robinson.com",
+    "contacts": Contact.from_dict({"first_name": "Jabber", "last_name": "Robinson"}),
     "authority": "Parrot law, subsection 4",
     "effective_date": datetime.datetime(2020, 6, 8),
     "register_date": datetime.datetime(2020, 7, 20),

--- a/test_data_ingest/models/test_regulation.py
+++ b/test_data_ingest/models/test_regulation.py
@@ -16,7 +16,7 @@ MOCK_REGULATION = {
     "volume": "19",
     "regulation_number": "VA-001",
     "description": "The best reg ever!",
-    "body": "You really don't want to read this whole thing ...",
+    "body": "You <s>really</s> don't want to read this whole thing ...",
     "summary": "This is such a great reg",
     "preamble": "This is such a great reg",
     "titles": [{"title": "VA-001", "description": "Fish"}],
@@ -50,7 +50,7 @@ REGULATION_XML = """
   <preamble>This is such a great reg</preamble>
   <summary>This is such a great reg</summary>
   <body>
-    You really don't want to read this whole thing ...
+    You <s>really</s> don't want to read this whole thing ...
   </body>
 <contacts>
   <contact>

--- a/test_data_ingest/regs/test_va.py
+++ b/test_data_ingest/regs/test_va.py
@@ -195,3 +195,12 @@ def test_get_loaded_issues(tmpdir):
     with modified_environ(**env):
         loaded_issues = regs._get_loaded_issues(tmpdir.dirname)
         assert loaded_issues == {("01", "01"), ("01", "02"), ("02", "01"), ("03", "01")}
+
+
+def test_parse_contact():
+    example = "Jenn Parsons, 215-867-5309, jann@jenn.com"
+    first_name, last_name, email, phone = regs._parse_contact(example)
+    assert first_name == "Jenn"
+    assert last_name == "Parsons"
+    assert email == "jann@jenn.com"
+    assert phone == "215-867-5309"

--- a/test_data_ingest/regs/test_va.py
+++ b/test_data_ingest/regs/test_va.py
@@ -119,8 +119,8 @@ def test_get_regulation(monkeypatch):
         "summary": "A wonderful summary!",
         "preamble": "A wonderful preamble!",
         "titles": [
-            {"title": "VA-001", "description": "Fish"},
-            {"title": "VA-002", "description": "Lobsters"},
+            {"code": "VA-001", "description": "Fish"},
+            {"code": "VA-002", "description": "Lobsters"},
         ],
         "contact": "Jabber Robinson, jabber@robinson.com",
         "authority": "Parrot law, subsection 4",

--- a/test_data_ingest/regs/test_va.py
+++ b/test_data_ingest/regs/test_va.py
@@ -56,7 +56,12 @@ def test_get_issue(monkeypatch):
 TEST_REGULATION = """
 <html>
     <div class="currentIssue-DateIssue">Vol. 19 Iss. 14 - June 01, 2020</div>
-    <p class="textbl"><u>Titles of Regulation:s</b></p>
+    <div id="ContentPlaceHolder1_divTitle" class="titleDescription">TITLE 4. CONSERVATION AND NATURAL RESOURCES</div>
+    <div id="ContentPlaceHolder1_divDescription" class="chapDescription">MARINE RESOURCES COMMISSION</div>
+    <div id="ContentPlaceHolder1_divChapter" class="chapDescription">Chapter 252</div>
+    <div id="ContentPlaceHolder1_divStatus" class="statusDescription">Final Regulation</div>
+    <p class="notice0"><u>REGISTRAR'S NOTICE:</u> Be aware of the notice!</p>
+    <p class="textbl"><u>Titles of Regulations</b></p>
     <p class="textbl"><b> VA-001. Fish</b></p>
     <p class="textbl"><strong> VA-002. Lobsters</strong></p>
     <p class="textbl">
@@ -95,6 +100,11 @@ def test_get_regulation(monkeypatch):
 
     regulation = regs.get_regulation("fake_id")
     assert regulation == {
+        "chapter": "Chapter 252",
+        "chapter_description": "MARINE RESOURCES COMMISSION",
+        "status": "Final Regulation",
+        "title": "TITLE 4. CONSERVATION AND NATURAL RESOURCES",
+        "notice": "<u>REGISTRAR'S NOTICE:</u> Be aware of the notice!",
         "issue": "14",
         "volume": "19",
         "content": {

--- a/test_data_ingest/regs/test_va.py
+++ b/test_data_ingest/regs/test_va.py
@@ -76,7 +76,7 @@ TEST_REGULATION = """
     <p class="preamble">Preamble:</p>
     <p>A wonderful preamble!</p>
     <p class="vacno0">VA-001. Good Reg</p>
-    <p class="sectind0">A<s>n</s> good<s>outstanding</s></p>
+    <p class="sectind0">A<s>n</s> good<s><u>outstanding</u></s></p>
     <p class="sectind0">reg</p>
     <p class="vacno0">VA-002. Bad Reg</p>
     <p class="sectind0">A bad</p>
@@ -98,7 +98,10 @@ def test_get_regulation(monkeypatch):
         "issue": "14",
         "volume": "19",
         "content": {
-            "VA-001": {"description": "Good Reg", "text": "A good reg"},
+            "VA-001": {
+                "description": "Good Reg",
+                "text": "A<s>n</s> good<s><u>outstanding</u></s> reg",
+            },
             "VA-002": {"description": "Bad Reg", "text": "A bad reg"},
         },
         "summary": "A wonderful summary!",

--- a/test_data_ingest/utils/test_config.py
+++ b/test_data_ingest/utils/test_config.py
@@ -1,4 +1,7 @@
+import os.path as path
+
 import data_ingest.utils.config as config
+from data_ingest.utils.environ import modified_environ
 
 
 def test_news_config_is_well_formed():
@@ -14,3 +17,17 @@ def test_news_ids_are_unique():
     newspaper_config = config.read_config("newspaper")
     ids = [value["id"] for value in newspaper_config]
     assert len(ids) == len(set(ids))
+
+
+def test_local_regs_get_dir_from_env(tmpdir):
+    env = {"CIVIC_JABBER_DATA_DIR": tmpdir.dirname}
+    with modified_environ(**env):
+        assert config.local_regs_directory() == tmpdir.dirname
+
+
+def test_local_regs_makes_dir_with_no_env_var(monkeypatch, tmpdir):
+    monkeypatch.setattr(path, "expanduser", lambda x: tmpdir.dirname)
+    correct_directory = path.join(tmpdir.dirname, ".civic_jabber", "regs")
+    local_directory = config.local_regs_directory()
+    assert path.exists(correct_directory)
+    assert local_directory == correct_directory

--- a/test_data_ingest/utils/test_config.py
+++ b/test_data_ingest/utils/test_config.py
@@ -22,7 +22,7 @@ def test_news_ids_are_unique():
 def test_local_regs_get_dir_from_env(tmpdir):
     env = {"CIVIC_JABBER_DATA_DIR": tmpdir.dirname}
     with modified_environ(**env):
-        assert config.local_regs_directory() == tmpdir.dirname
+        assert config.local_regs_directory() == path.join(tmpdir.dirname, "regs")
 
 
 def test_local_regs_makes_dir_with_no_env_var(monkeypatch, tmpdir):

--- a/test_data_ingest/utils/test_data_cleaning.py
+++ b/test_data_ingest/utils/test_data_cleaning.py
@@ -17,3 +17,13 @@ def test_extract_date_returns_none_with_non_string():
 
 def test_clean_whitespace():
     clean.clean_whitespace("  parrots  ") == "parrots"
+
+
+def test_extract_phone_number():
+    example = "Jenn Walker, 215-867-5309, jenn@walker.com"
+    assert clean.extract_phone_number(example) == "215-867-5309"
+
+
+def test_extract_email():
+    example = "Jenn Walker, 215-867-5309, jenn@walker.com"
+    assert clean.extract_email(example) == "jenn@walker.com"

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -7,19 +7,38 @@ import data_ingest.utils.xml as xml
 @pytest.fixture
 def valid_regulation():
     return """
-        <regulation>
-            <state>VA</state>
-            <issue>1</issue>
-            <titles>
-                <title>
-                    4VAC20-252
-                </title>
-                <title>
-                    4VAC20-254
-                </title>
-            </titles>
-        </regulation>
-    """
+<regulation>
+  <state>VA</state>
+  <issue>14</issue>
+  <volume>19</volume>
+  <notice>Notice: this is a great reg!</notice>
+  <effectiveDate>2020-06-08</effectiveDate>
+  <link>https://thebestregs.com</link>
+  <status>Final Regulation</status>
+  <chapter>Chapter 4</chapter>
+  <chapterDescription></chapterDescription>
+  <title>14-1831</title>
+<titles>
+  <title>
+    <code>VA-001</code>
+    <description>Fish</description>
+  </title>
+</titles>
+  <statuatoryAuthority>Parrot law, subsection 4</statuatoryAuthority>
+  <description>The best reg ever!</description>
+  <preamble>This is such a great reg</preamble>
+  <summary>This is such a great reg</summary>
+  <body>
+    You <s>really</s> don't want to read this whole thing ...
+  </body>
+<contacts>
+  <contact>
+<firstName>Jabber</firstName>
+<lastName>Robinson</lastName>
+  </contact>
+</contacts>
+</regulation>
+""".strip()
 
 
 @pytest.fixture

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -1,5 +1,4 @@
 import pytest
-from lxml import etree
 
 import data_ingest.utils.xml as xml
 
@@ -63,10 +62,8 @@ def invalid_regulation():
 
 
 def test_parser_validates_valid_reg(valid_regulation):
-    root = xml.read_xml(valid_regulation, "regulation")
-    assert isinstance(root, etree._Element)
+    assert xml.validate_xml(valid_regulation, "regulation") is True
 
 
 def test_parser_raises_on_invalid_reg(invalid_regulation):
-    with pytest.raises(etree.XMLSyntaxError):
-        xml.read_xml(invalid_regulation, "regulation")
+    assert xml.validate_xml(invalid_regulation, "regulation") is False

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -12,12 +12,10 @@ def valid_regulation():
             <issue>1</issue>
             <titles>
                 <title>
-                    <code>4VAC20-252</code>
-                    <description>Parrots</description>
+                    4VAC20-252
                 </title>
                 <title>
-                    <code>4VAC20-254</code>
-                    <description>Dogs</description>
+                    4VAC20-254
                 </title>
             </titles>
         </regulation>

--- a/test_data_ingest/utils/test_xml.py
+++ b/test_data_ingest/utils/test_xml.py
@@ -57,6 +57,7 @@ def invalid_regulation():
                     <description>Dogs</description>
                 </title>
             </titles>
+            <koala>Kenny Koala</koala>
         </regulation>
     """
 


### PR DESCRIPTION
### Summary

Addresses #9 to update the VA regulation to build XML files instead of writing the regs to the database. In addition, this PR makes the following changes.

1. Maintains markdown such as strikethroughs and underlines. This also entails changes to the `.xsd` schema.
1. We now extract title and chapter information, regulation status, and registrar's notices for VA regs.
1. Adds the ability for data classes to serialize to XML.
1. Adds a data class for contacts.
1. Adds `jinja2` to the dependencies.
1. Sets the local directory for the regs to be stored as `~/.civic_jabber/regs`. This can be overwritten with the `CIVIC_JABBER_DATA_DIR` environment variable.

### Test Instructions

```
pytest test_data_ingest/regs/test_va.py
pytest test_data_ingest/models
```

In addition to unit test, I tested this locally by running the following:

```python
from data_ingest.regs.va import load_va_regulations

load_va_regulations()
```

The code locally as expected. There were, however, a bunch of warnings about invalid XML in Volume 25, Issue 01. I spun of #18  to capture the bug fix for those warnings.