### PR TITLE
Added Airflow to automate dialy data ingests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ lint:
 lint-black:
 	black civic_jabber_ingest --check
 	black test_civic_jabber_ingest --check
+	black dags --check
 
 tidy:
 	black civic_jabber_ingest
 	black test_civic_jabber_ingest
+	black dags
 
 test:
 	pytest test_civic_jabber_ingest --cov=civic_jabber_ingest -vv -m "not slow"
+	python dags/states.py # Checks to make sure the DAG is valid
 
 ################
 # Install

--- a/README.md
+++ b/README.md
@@ -31,10 +31,28 @@ To use the AWS utilities, you'll also need to install the AWS CLI with
 ```
 sudo apt-get install awscli
 ```
+
 Once you install the AWS CLI, you can set up your profile with `aws configure`. For now,
 only Matt has access to the AWS resources. As the project moves on, we may give select
 people access to dev AWS resources.
 
+The following dependencies are required to run Airflow:
+
+```
+sudo apt-get install -y --no-install-recommends \
+        freetds-bin \
+        krb5-user \
+        ldap-utils \
+        libffi6 \
+        libsasl2-2 \
+        libsasl2-modules \
+        libssl1.1 \
+        locales  \
+        lsb-release \
+        sasl2-bin \
+        sqlite3 \
+        unixodbc
+```
 
 The following packages are required for `newspaper` to recognize `.jpg` images
 ```

--- a/civic_jabber_ingest/regs/va.py
+++ b/civic_jabber_ingest/regs/va.py
@@ -71,7 +71,7 @@ def load_va_regulations(sleep_time=1, local=True, dev=False):
         aws.sync_state("va")
 
 
-def _get_loaded_issues(directory=None, local=True, dev=True):
+def _get_loaded_issues(directory=None, local=True, dev=False):
     """Pulls a list of issues and volumes that have already been loaded in the local
     filesystem
 

--- a/dags/states.py
+++ b/dags/states.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+from functools import partial
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+from civic_jabber_ingest.regs.va import load_va_regulations
+
+default_args = {
+    "owner": "civic-jabber",
+    "depends_on_past": False,
+    "start_date": datetime.today(),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+
+dag = DAG(
+    "civic-jabber-states", default_args=default_args, schedule_interval="0 4 * * *"
+)
+
+
+run_va = partial(load_va_regulations, local=False)
+load_va = PythonOperator(task_id="va-regulations-load", python_callable=run_va, dag=dag)

--- a/dags/states.py
+++ b/dags/states.py
@@ -9,7 +9,7 @@ from civic_jabber_ingest.regs.va import load_va_regulations
 default_args = {
     "owner": "civic-jabber",
     "depends_on_past": False,
-    "start_date": datetime.today(),
+    "start_date": datetime.today() - timedelta(days=1),
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,4 @@
+apache-airflow
 beautifulsoup4
 boto3
 click

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-apache-airflow
+apache-airflow[password]
 beautifulsoup4
 boto3
 click

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,39 +4,127 @@
 #
 #    pip-compile requirements/base.in
 #
+alembic==1.4.3            # via apache-airflow
+apache-airflow-providers-ftp==1.0.0  # via apache-airflow
+apache-airflow-providers-http==1.0.0  # via apache-airflow
+apache-airflow-providers-imap==1.0.0  # via apache-airflow
+apache-airflow-providers-sqlite==1.0.0  # via apache-airflow
+apache-airflow==2.0.0     # via -r requirements/base.in, apache-airflow-providers-ftp, apache-airflow-providers-http, apache-airflow-providers-imap, apache-airflow-providers-sqlite
+apispec[yaml]==3.3.2      # via flask-appbuilder
+argcomplete==1.12.2       # via apache-airflow
+attrs==20.3.0             # via apache-airflow, cattrs, jsonschema
+babel==2.9.0              # via flask-babel
 beautifulsoup4==4.9.1     # via -r requirements/base.in, feedfinder2, newspaper3k
 boto3==1.16.35            # via -r requirements/base.in
 botocore==1.19.35         # via boto3, s3transfer
+cached-property==1.5.2    # via apache-airflow
+cattrs==1.1.2             # via apache-airflow
 certifi==2020.6.20        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.2              # via -r requirements/base.in, nltk
+click==7.1.2              # via -r requirements/base.in, clickclick, flask, flask-appbuilder, nltk
+clickclick==20.10.2       # via connexion
+colorama==0.4.4           # via flask-appbuilder, rich
+colorlog==4.0.2           # via apache-airflow
+commonmark==0.9.1         # via rich
+connexion[flask,swagger-ui]==2.7.0  # via apache-airflow
+croniter==0.3.36          # via apache-airflow
+cryptography==3.3.1       # via apache-airflow
 cssselect==1.1.0          # via newspaper3k
+defusedxml==0.6.0         # via python3-openid
+dill==0.3.3               # via apache-airflow
+dnspython==2.0.0          # via email-validator
+docutils==0.16            # via python-daemon
+email-validator==1.1.2    # via flask-appbuilder
 feedfinder2==0.0.4        # via newspaper3k
 feedparser==6.0.1         # via newspaper3k
-idna==2.10                # via requests, tldextract
+flask-appbuilder==3.1.1   # via apache-airflow
+flask-babel==1.0.0        # via flask-appbuilder
+flask-caching==1.9.0      # via apache-airflow
+flask-jwt-extended==3.25.0  # via flask-appbuilder
+flask-login==0.4.1        # via apache-airflow, flask-appbuilder
+flask-openid==1.2.5       # via flask-appbuilder
+flask-sqlalchemy==2.4.4   # via flask-appbuilder
+flask-swagger==0.2.13     # via apache-airflow
+flask-wtf==0.14.3         # via apache-airflow, flask-appbuilder
+flask==1.1.2              # via apache-airflow, connexion, flask-appbuilder, flask-babel, flask-caching, flask-jwt-extended, flask-login, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
+funcsigs==1.0.2           # via apache-airflow
+graphviz==0.15            # via apache-airflow
+gunicorn==19.10.0         # via apache-airflow
+idna==2.10                # via email-validator, requests, tldextract
+importlib-metadata==1.7.0  # via apache-airflow
+importlib-resources==1.5.0  # via apache-airflow
+inflection==0.5.1         # via connexion
+iso8601==0.1.13           # via apache-airflow
+itsdangerous==1.1.0       # via apache-airflow, flask, flask-wtf
 jieba3k==0.35.1           # via newspaper3k
-jinja2==2.11.2            # via -r requirements/base.in
+jinja2==2.11.2            # via -r requirements/base.in, apache-airflow, flask, flask-babel, python-nvd3, swagger-ui-bundle
 jmespath==0.10.0          # via boto3, botocore
 joblib==0.17.0            # via nltk
+json-merge-patch==0.2     # via apache-airflow
+jsonschema==3.2.0         # via apache-airflow, connexion, flask-appbuilder, openapi-spec-validator
+lazy-object-proxy==1.4.3  # via apache-airflow
+lockfile==0.12.2          # via apache-airflow, python-daemon
 lxml==4.5.2               # via -r requirements/base.in, newspaper3k
-markupsafe==1.1.1         # via jinja2
+mako==1.1.3               # via alembic
+markdown==3.3.3           # via apache-airflow
+markupsafe==1.1.1         # via apache-airflow, jinja2, mako, wtforms
+marshmallow-enum==1.5.1   # via flask-appbuilder
+marshmallow-oneofschema==2.1.0  # via apache-airflow
+marshmallow-sqlalchemy==0.23.1  # via flask-appbuilder
+marshmallow==3.9.1        # via flask-appbuilder, marshmallow-enum, marshmallow-oneofschema, marshmallow-sqlalchemy
+natsort==7.1.0            # via croniter
 newspaper3k==0.2.8        # via -r requirements/base.in
 nltk==3.5                 # via newspaper3k
 numpy==1.19.1             # via pandas
-pandas==1.1.0             # via -r requirements/base.in
+openapi-spec-validator==0.2.9  # via connexion
+pandas==1.1.0             # via -r requirements/base.in, apache-airflow
+pendulum==2.1.2           # via apache-airflow
 pillow==7.2.0             # via newspaper3k
+prison==0.1.3             # via flask-appbuilder
+psutil==5.8.0             # via apache-airflow
 psycopg2-binary==2.8.6    # via -r requirements/base.in
-python-dateutil==2.8.1    # via botocore, newspaper3k, pandas
-pytz==2020.1              # via pandas
-pyyaml==5.3.1             # via newspaper3k
+pycparser==2.20           # via cffi
+pygments==2.7.3           # via apache-airflow, rich
+pyjwt==1.7.1              # via flask-appbuilder, flask-jwt-extended
+pyrsistent==0.17.3        # via jsonschema
+python-daemon==2.2.4      # via apache-airflow
+python-dateutil==2.8.1    # via alembic, apache-airflow, botocore, croniter, flask-appbuilder, newspaper3k, pandas, pendulum
+python-editor==1.0.4      # via alembic
+python-nvd3==0.15.0       # via apache-airflow
+python-slugify==4.0.1     # via apache-airflow, python-nvd3
+python3-openid==3.2.0     # via flask-openid
+pytz==2020.1              # via babel, flask-babel, pandas, tzlocal
+pytzdata==2020.1          # via pendulum
+pyyaml==5.3.1             # via apispec, clickclick, connexion, flask-swagger, newspaper3k, openapi-spec-validator
 regex==2020.9.27          # via nltk
 requests-file==1.5.1      # via tldextract
-requests==2.24.0          # via -r requirements/base.in, feedfinder2, newspaper3k, requests-file, tldextract
+requests==2.23.0          # via -r requirements/base.in, apache-airflow, connexion, feedfinder2, newspaper3k, requests-file, tldextract
+rich==9.2.0               # via apache-airflow
 s3transfer==0.3.3         # via boto3
+setproctitle==1.2.1       # via apache-airflow
 sgmllib3k==1.0.0          # via feedparser
-six==1.15.0               # via feedfinder2, python-dateutil, requests-file
+six==1.15.0               # via cryptography, feedfinder2, flask-jwt-extended, jsonschema, openapi-spec-validator, prison, python-dateutil, requests-file, sqlalchemy-utils, tenacity, thrift
 soupsieve==2.0.1          # via beautifulsoup4
+sqlalchemy-jsonfield==1.0.0  # via apache-airflow
+sqlalchemy-utils==0.36.8  # via flask-appbuilder
+sqlalchemy==1.3.22        # via alembic, apache-airflow, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-jsonfield, sqlalchemy-utils
+swagger-ui-bundle==0.0.8  # via connexion
+tabulate==0.8.7           # via apache-airflow
+tenacity==6.2.0           # via apache-airflow
+termcolor==1.1.0          # via apache-airflow
+text-unidecode==1.3       # via python-slugify
+thrift==0.13.0            # via apache-airflow
 tinysegmenter==0.3        # via newspaper3k
 tldextract==2.2.3         # via newspaper3k
 tqdm==4.49.0              # via -r requirements/base.in, nltk
-urllib3==1.25.10          # via botocore, requests
+typing-extensions==3.7.4.3  # via rich
+tzlocal==1.5.1            # via apache-airflow
+unicodecsv==0.14.1        # via apache-airflow
+urllib3==1.25.10          # via apache-airflow, botocore, requests
+werkzeug==1.0.1           # via apache-airflow, flask, flask-jwt-extended
+wtforms==2.3.3            # via flask-wtf
+zipp==3.4.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,18 +9,19 @@ apache-airflow-providers-ftp==1.0.0  # via apache-airflow
 apache-airflow-providers-http==1.0.0  # via apache-airflow
 apache-airflow-providers-imap==1.0.0  # via apache-airflow
 apache-airflow-providers-sqlite==1.0.0  # via apache-airflow
-apache-airflow==2.0.0     # via -r requirements/base.in, apache-airflow-providers-ftp, apache-airflow-providers-http, apache-airflow-providers-imap, apache-airflow-providers-sqlite
+apache-airflow[password]==2.0.0  # via -r requirements/base.in, apache-airflow-providers-ftp, apache-airflow-providers-http, apache-airflow-providers-imap, apache-airflow-providers-sqlite
 apispec[yaml]==3.3.2      # via flask-appbuilder
 argcomplete==1.12.2       # via apache-airflow
 attrs==20.3.0             # via apache-airflow, cattrs, jsonschema
 babel==2.9.0              # via flask-babel
+bcrypt==3.2.0             # via apache-airflow, flask-bcrypt
 beautifulsoup4==4.9.1     # via -r requirements/base.in, feedfinder2, newspaper3k
 boto3==1.16.35            # via -r requirements/base.in
 botocore==1.19.35         # via boto3, s3transfer
 cached-property==1.5.2    # via apache-airflow
 cattrs==1.1.2             # via apache-airflow
 certifi==2020.6.20        # via requests
-cffi==1.14.4              # via cryptography
+cffi==1.14.4              # via bcrypt, cryptography
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements/base.in, clickclick, flask, flask-appbuilder, nltk
 clickclick==20.10.2       # via connexion
@@ -40,6 +41,7 @@ feedfinder2==0.0.4        # via newspaper3k
 feedparser==6.0.1         # via newspaper3k
 flask-appbuilder==3.1.1   # via apache-airflow
 flask-babel==1.0.0        # via flask-appbuilder
+flask-bcrypt==0.7.1       # via apache-airflow
 flask-caching==1.9.0      # via apache-airflow
 flask-jwt-extended==3.25.0  # via flask-appbuilder
 flask-login==0.4.1        # via apache-airflow, flask-appbuilder
@@ -47,7 +49,7 @@ flask-openid==1.2.5       # via flask-appbuilder
 flask-sqlalchemy==2.4.4   # via flask-appbuilder
 flask-swagger==0.2.13     # via apache-airflow
 flask-wtf==0.14.3         # via apache-airflow, flask-appbuilder
-flask==1.1.2              # via apache-airflow, connexion, flask-appbuilder, flask-babel, flask-caching, flask-jwt-extended, flask-login, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
+flask==1.1.2              # via apache-airflow, connexion, flask-appbuilder, flask-babel, flask-bcrypt, flask-caching, flask-jwt-extended, flask-login, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
 funcsigs==1.0.2           # via apache-airflow
 graphviz==0.15            # via apache-airflow
 gunicorn==19.10.0         # via apache-airflow
@@ -104,7 +106,7 @@ rich==9.2.0               # via apache-airflow
 s3transfer==0.3.3         # via boto3
 setproctitle==1.2.1       # via apache-airflow
 sgmllib3k==1.0.0          # via feedparser
-six==1.15.0               # via cryptography, feedfinder2, flask-jwt-extended, jsonschema, openapi-spec-validator, prison, python-dateutil, requests-file, sqlalchemy-utils, tenacity, thrift
+six==1.15.0               # via bcrypt, cryptography, feedfinder2, flask-jwt-extended, jsonschema, openapi-spec-validator, prison, python-dateutil, requests-file, sqlalchemy-utils, tenacity, thrift
 soupsieve==2.0.1          # via beautifulsoup4
 sqlalchemy-jsonfield==1.0.0  # via apache-airflow
 sqlalchemy-utils==0.36.8  # via flask-appbuilder

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -7,5 +7,5 @@ project_path=$(dirname "$script_path")
 
 # Airflow
 export AIRFLOW__CORE__DAGS_FOLDER=${project_path}/dags
-export AIRFLOW__LOGGING__LOGGING_LEVEL=WARN
+export AIRFLOW__LOGGING__LOGGING_LEVEL=INFO
 export AIRFLOW__CORE__LOAD_EXAMPLES=False

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Get the full real path to the scripts directory and the project directory
+full_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+script_path=$(dirname "$full_path")
+project_path=$(dirname "$script_path")
+
+# Airflow
+export AIRFLOW__CORE__DAGS_FOLDER=${project_path}/dags

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -8,3 +8,4 @@ project_path=$(dirname "$script_path")
 # Airflow
 export AIRFLOW__CORE__DAGS_FOLDER=${project_path}/dags
 export AIRFLOW__LOGGING__LOGGING_LEVEL=WARN
+export AIRFLOW__CORE__LOAD_EXAMPLES=False

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -7,3 +7,4 @@ project_path=$(dirname "$script_path")
 
 # Airflow
 export AIRFLOW__CORE__DAGS_FOLDER=${project_path}/dags
+export AIRFLOW__LOGGING__LOGGING_LEVEL=WARN


### PR DESCRIPTION
Addresses #20 to add Airflow to automate data ingests. This PR does the follows:

1. Adds Airflow as a dependency
2. Adds an `env.sh` script that sets the appropriate environmental variables for Airflow
3. Creates a DAG for the process to load the regulations. Currently, this only loads the regulations for VA.

Confirmed that Airflow works and schedules the jobs as intended by setting up and running locally. Note, we have username/password authentication set up for Airflow, so you'll need to do something along the lines of the follow to set up a user for yourself if you want to try this for yourself:

```
    $ airflow users create \
          --username admin \
          --firstname FIRST_NAME \
          --lastname LAST_NAME \
          --role Admin \
          --email admin@example.org
```